### PR TITLE
fix for scoreUri shadowing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,4 @@ jobs:
         artifacts: "src/dist/windows/vpc-get-high-scores-image.exe,src/POPMENU_GetHighScoresForAllTables.bat,src/playsound.exe,src/UpdateHighScoreStart.mp3,src/UpdateHighScoreStop.mp3"
         token: ${{ secrets.GH_TOKEN }}
         commit: ${{ github.sha }}
-        tag: v1.2.8
+        tag: v1.2.9

--- a/src/createHighScoreImage.py
+++ b/src/createHighScoreImage.py
@@ -85,7 +85,7 @@ def fetchHighScoreImage(vpsId, fieldNames, numRows, mediaPath):
   scoreList += "Screen Name: " + gameDisplay + "\n"
   scoreList += "Author: " + authorName + "\n\n"
  
-  scoreUri = scoreUri + urllib.parse.quote(vpsId)
+  scoreFullUri = scoreUri + urllib.parse.quote(vpsId)
 
   session = requests.Session()
   retry = Retry(connect=3, backoff_factor=1.0)
@@ -93,7 +93,7 @@ def fetchHighScoreImage(vpsId, fieldNames, numRows, mediaPath):
   session.mount('http://', adapter)
   session.mount('https://', adapter)
 
-  tables = (session.get(scoreUri)).json()
+  tables = (session.get(scoreFullUri)).json()
 
   if len(tables) > 0:
     limitedList = tables[0]['scores'][:numRows]


### PR DESCRIPTION
Python sees the left-hand scoreUri as a local variable. When it tries to evaluate the right side, that local hasn’t been set yet.